### PR TITLE
Remove glow behind player

### DIFF
--- a/dracula.user.css
+++ b/dracula.user.css
@@ -132,4 +132,9 @@ paper-toggle-button[checked]:not([disabled]) .toggle-bar.paper-toggle-button
 .sbfl_b {
      color: #8be9fd;   
 }
+    
+/* hide weird glow behind player */
+#cinematics {
+    display: none;
+}
 }


### PR DESCRIPTION
For some reason, youtube thought it's a good idea to add a glow behind the video player. This glow however makes a part of the background be the default black rather than the dracula one. This commit removes the glow altogether, thus making the whole background the dracula color we all know and love.

**Before**
![before](https://user-images.githubusercontent.com/63104422/211912320-fd2332ec-1e66-4e8a-b5c8-7045a5bcca76.png)

**After**
![after](https://user-images.githubusercontent.com/63104422/211912681-faac6667-98ee-4ea8-8053-fc786eab79da.png)
